### PR TITLE
1inch bsc strategies

### DIFF
--- a/contracts/base/inheritance/RewardTokenProfitNotifier.sol
+++ b/contracts/base/inheritance/RewardTokenProfitNotifier.sol
@@ -20,8 +20,8 @@ contract RewardTokenProfitNotifier is Controllable {
   ) public Controllable(_storage){
     rewardToken = _rewardToken;
     // persist in the state for immutability of the fee
-    profitSharingNumerator = 30; //IController(controller()).profitSharingNumerator();
-    profitSharingDenominator = 100; //IController(controller()).profitSharingDenominator();
+    profitSharingNumerator = 80; //IController(controller()).profitSharingNumerator();
+    profitSharingDenominator = 1000; //IController(controller()).profitSharingDenominator();
     require(profitSharingNumerator < profitSharingDenominator, "invalid profit share");
   }
 

--- a/contracts/base/masterchef/GeneralMasterChefStrategy.sol
+++ b/contracts/base/masterchef/GeneralMasterChefStrategy.sol
@@ -50,7 +50,7 @@ contract GeneralMasterChefStrategy is BaseUpgradeableStrategy {
       _vault,
       _rewardPool,
       _rewardToken,
-      300, // profit sharing numerator
+      80, // profit sharing numerator
       1000, // profit sharing denominator
       true, // sell
       1e16, // sell floor

--- a/contracts/base/pancake-base/PancakeMasterChefStrategy.sol
+++ b/contracts/base/pancake-base/PancakeMasterChefStrategy.sol
@@ -50,7 +50,7 @@ contract PancakeMasterChefStrategy is BaseUpgradeableStrategy {
       _vault,
       _rewardPool,
       _rewardToken,
-      300, // profit sharing numerator
+      80, // profit sharing numerator
       1000, // profit sharing denominator
       true, // sell
       1e18, // sell floor

--- a/contracts/base/venus-base/VenusFoldStrategy.sol
+++ b/contracts/base/venus-base/VenusFoldStrategy.sol
@@ -60,7 +60,7 @@ contract VenusFoldStrategy is BaseUpgradeableStrategy, VenusInteractorInitializa
       _vault,
       _comptroller,
       _xvs,
-      300, // profit sharing numerator
+      80, // profit sharing numerator
       1000, // profit sharing denominator
       true, // sell
       1e16, // sell floor

--- a/contracts/base/venus-base/VenusWBNBFoldStrategy.sol
+++ b/contracts/base/venus-base/VenusWBNBFoldStrategy.sol
@@ -59,7 +59,7 @@ contract VenusWBNBFoldStrategy is BaseUpgradeableStrategy, VenusInteractorInitia
       _vault,
       _comptroller,
       _xvs,
-      300, // profit sharing numerator
+      80, // profit sharing numerator
       1000, // profit sharing denominator
       true, // sell
       1e16, // sell floor

--- a/contracts/strategies/1inch/OneInchStrategyMainnet_1INCH_BNB.sol
+++ b/contracts/strategies/1inch/OneInchStrategyMainnet_1INCH_BNB.sol
@@ -1,0 +1,22 @@
+pragma solidity 0.6.12;
+
+import "./OneInchStrategy_1INCH_BNB.sol";
+
+
+/**
+* This strategy is for the 1INCH/BNB LP token on 1inch
+*/
+contract OneInchStrategyMainnet_1INCH_BNB is OneInchStrategy_1INCH_BNB {
+
+  constructor(
+    address _storage,
+    address _vault
+  ) OneInchStrategy_1INCH_BNB (
+    _storage,
+    _vault,
+    address(0xdaF66c0B7e8E2FC76B15B07AD25eE58E04a66796), // underlying
+    address(0x5D0EC1F843c1233D304B96DbDE0CAB9Ec04D71EF) // pool
+  ) public {
+    require(token1 == oneInch, "token1 mismatch");
+  }
+}

--- a/contracts/strategies/1inch/OneInchStrategyMainnet_1INCH_renBTC.sol
+++ b/contracts/strategies/1inch/OneInchStrategyMainnet_1INCH_renBTC.sol
@@ -17,7 +17,8 @@ contract OneInchStrategyMainnet_1INCH_renBTC is OneInchStrategy_1INCH_renBTC {
     _storage,
     _vault,
     address(0xe3f6509818ccf031370bB4cb398EB37C21622ac4), // underlying
-    address(0xCB06dF7F0Be5B8Bb261d294Cf87C794EB9Da85b1) // pool
+    address(0xCB06dF7F0Be5B8Bb261d294Cf87C794EB9Da85b1), // pool
+    address(0xdaF66c0B7e8E2FC76B15B07AD25eE58E04a66796)  // 1inch-bnb LP
   ) public {
     require(token1 == renBTC, "token1 mismatch");
   }

--- a/contracts/strategies/1inch/OneInchStrategyMainnet_1INCH_renBTC.sol
+++ b/contracts/strategies/1inch/OneInchStrategyMainnet_1INCH_renBTC.sol
@@ -1,0 +1,24 @@
+pragma solidity 0.6.12;
+
+import "./OneInchStrategy_1INCH_renBTC.sol";
+
+
+/**
+* This strategy is for the 1INCH/renBTC LP token on 1inch
+*/
+contract OneInchStrategyMainnet_1INCH_renBTC is OneInchStrategy_1INCH_renBTC {
+
+  bool public unused_is_1inch;
+
+  constructor(
+    address _storage,
+    address _vault
+  ) OneInchStrategy_1INCH_renBTC (
+    _storage,
+    _vault,
+    address(0xe3f6509818ccf031370bB4cb398EB37C21622ac4), // underlying
+    address(0xCB06dF7F0Be5B8Bb261d294Cf87C794EB9Da85b1) // pool
+  ) public {
+    require(token1 == renBTC, "token1 mismatch");
+  }
+}

--- a/contracts/strategies/1inch/OneInchStrategy_1INCH_BNB.sol
+++ b/contracts/strategies/1inch/OneInchStrategy_1INCH_BNB.sol
@@ -1,0 +1,198 @@
+pragma solidity 0.6.12;
+
+import "@pancakeswap/pancake-swap-lib/contracts/token/BEP20/IBEP20.sol";
+import "@pancakeswap/pancake-swap-lib/contracts/token/BEP20/SafeBEP20.sol";
+import "@openzeppelin/contracts-upgradeable/math/MathUpgradeable.sol";
+import "@pancakeswap/pancake-swap-lib/contracts/math/SafeMath.sol";
+import "@pancakeswap/pancake-swap-lib/contracts/utils/Address.sol";
+import "./interface/IMooniswap.sol";
+import "./interface/IFarmingRewards.sol";
+
+import "../../base/interface/pancakeswap/IPancakeRouter02.sol";
+import "../../base/interface/IVault.sol";
+
+import "../../base/StrategyBase.sol";
+
+/**
+* This strategy is for 1INCH / BNB 1inch LP tokens
+* 1INCH must be token0, and the other token is BNB
+*/
+contract OneInchStrategy_1INCH_BNB is StrategyBase {
+
+  using SafeBEP20 for IBEP20;
+  using Address for address;
+  using SafeMath for uint256;
+
+  event Liquidating(address token, uint256 amount);
+  event ProfitsNotCollected(address token);
+
+  address public pool;
+  address public oneInch = address(0x111111111117dC0aa78b770fA6A738034120C302);
+
+  uint256 maxUint = uint256(~0);
+  address public oneInchEthLP;
+
+  // token0 is ONEINCH
+  address public token1;
+
+  uint256 slippageNumerator = 9;
+  uint256 slippageDenominator = 10;
+
+  // a flag for disabling selling for simplified emergency exit
+  bool public sell = true;
+  // minimum 1inch amount to be liquidation
+  uint256 public sellFloorOneInch = 1e17;
+
+  constructor(
+    address _storage,
+    address _vault,
+    address _underlying,
+    address _pool
+  )
+  StrategyBase(_storage, _underlying, _vault, oneInch, address(0)) public {
+    require(IVault(_vault).underlying() == _underlying, "vault does not support the required LP token");
+    token1 = IMooniswap(_underlying).token1();
+    pool = _pool;
+    require(IMooniswap(_underlying).token1() == oneInch, "token1 must be 1INCH");
+
+    // making 1inch reward token salvagable to be able to
+    // liquidate externally
+    unsalvagableTokens[oneInch] = false;
+  }
+
+  function depositArbCheck() public view returns(bool) {
+    return true;
+  }
+
+  /**
+  * Salvages a token. We should not be able to salvage underlying.
+  */
+  function salvage(address recipient, address token, uint256 amount) public onlyGovernance {
+    // To make sure that governance cannot come in and take away the coins
+    require(!unsalvagableTokens[token], "token is defined as not salvageable");
+    IBEP20(token).safeTransfer(recipient, amount);
+  }
+
+  /**
+  * Withdraws underlying from the investment pool that mints crops.
+  */
+  function withdrawUnderlyingFromPool(uint256 amount) internal {
+    IFarmingRewards(pool).withdraw(
+      MathUpgradeable.min(IFarmingRewards(pool).balanceOf(address(this)), amount)
+    );
+  }
+
+  /**
+  * Withdraws the underlying tokens to the pool in the specified amount.
+  */
+  function withdrawToVault(uint256 amountUnderlying) external restricted {
+    withdrawUnderlyingFromPool(amountUnderlying);
+    require(IBEP20(underlying).balanceOf(address(this)) >= amountUnderlying, "insufficient balance for the withdrawal");
+    IBEP20(underlying).safeTransfer(vault, amountUnderlying);
+  }
+
+  /**
+  * Withdraws all the underlying tokens to the pool.
+  */
+  function withdrawAllToVault() external restricted {
+    claimAndLiquidate();
+    uint256 bal = IFarmingRewards(pool).balanceOf(address(this));
+    if (bal != 0) {
+      withdrawUnderlyingFromPool(maxUint);
+    }
+    uint256 balance = IBEP20(underlying).balanceOf(address(this));
+    IBEP20(underlying).safeTransfer(vault, balance);
+  }
+
+  /**
+  * Invests all the underlying into the pool that mints crops (1inch)
+  */
+  function investAllUnderlying() public restricted {
+    uint256 underlyingBalance = IBEP20(underlying).balanceOf(address(this));
+    if (underlyingBalance > 0) {
+      IBEP20(underlying).safeApprove(pool, 0);
+      IBEP20(underlying).safeApprove(pool, underlyingBalance);
+      IFarmingRewards(pool).stake(underlyingBalance);
+    }
+  }
+
+  /**
+  * Claims the 1Inch crop, converts it accordingly
+  */
+
+  function claimAndLiquidate() internal {
+    if (!sell) {
+      // Profits can be disabled for possible simplified and rapid exit
+      emit ProfitsNotCollected(oneInch);
+      return;
+    }
+    IFarmingRewards(pool).getReward();
+    uint256 oneInchBalance = IBEP20(oneInch).balanceOf(address(this));
+    if (oneInchBalance < sellFloorOneInch || oneInchBalance == 0) {
+      emit ProfitsNotCollected(oneInch);
+      return;
+    }
+
+    // share 30% of the 1INCH as a profit sharing reward
+    notifyProfitInRewardToken(oneInchBalance);
+
+    uint256 remainingBalance = IBEP20(oneInch).balanceOf(address(this));
+
+    IBEP20(oneInch).safeApprove(underlying, 0);
+    IBEP20(oneInch).safeApprove(underlying, remainingBalance.div(2));
+
+    // with the remaining, half would be converted into the second token
+    uint256 amountOutMin = 1;
+    IMooniswap(underlying).swap(oneInch, address(0), remainingBalance.div(2), amountOutMin, address(0));
+
+    uint256 oneInchAmount = IBEP20(oneInch).balanceOf(address(this));
+    uint256 bnbAmount = address(this).balance;
+
+    IBEP20(oneInch).safeApprove(underlying, 0);
+    IBEP20(oneInch).safeApprove(underlying, oneInchAmount);
+
+    // adding liquidity: ETH + token1
+    IMooniswap(underlying).deposit.value(bnbAmount)(
+      [bnbAmount, oneInchAmount],
+      [bnbAmount.mul(slippageNumerator).div(slippageDenominator),
+        oneInchAmount.mul(slippageNumerator).div(slippageDenominator)
+      ]
+    );
+  }
+
+  /**
+  * Claims and liquidates 1inch into underlying, and then invests all underlying.
+  */
+  function doHardWork() public restricted {
+    claimAndLiquidate();
+    investAllUnderlying();
+  }
+
+  /**
+  * Investing all underlying.
+  */
+  function investedUnderlyingBalance() public view returns (uint256) {
+    return IFarmingRewards(pool).balanceOf(address(this)).add(
+      IBEP20(underlying).balanceOf(address(this))
+    );
+  }
+
+  /**
+  * Can completely disable claiming 1inch rewards and selling. Good for emergency withdraw in the
+  * simplest possible way.
+  */
+  function setSell(bool s) public onlyGovernance {
+    sell = s;
+  }
+
+  /**
+  * Sets the minimum amount of 1inch needed to trigger a sale.
+  */
+  function setSellFloorAndSlippages(uint256 _sellFloorOneInch, uint256 _slippageNumerator, uint256 _slippageDenominator) public onlyGovernance {
+    sellFloorOneInch = _sellFloorOneInch;
+    slippageNumerator = _slippageNumerator;
+    slippageDenominator = _slippageDenominator;
+  }
+
+  receive() external payable {}
+}

--- a/contracts/strategies/1inch/OneInchStrategy_1INCH_renBTC.sol
+++ b/contracts/strategies/1inch/OneInchStrategy_1INCH_renBTC.sol
@@ -1,0 +1,213 @@
+pragma solidity 0.6.12;
+
+import "@pancakeswap/pancake-swap-lib/contracts/token/BEP20/IBEP20.sol";
+import "@pancakeswap/pancake-swap-lib/contracts/token/BEP20/SafeBEP20.sol";
+import "@openzeppelin/contracts-upgradeable/math/MathUpgradeable.sol";
+import "@pancakeswap/pancake-swap-lib/contracts/math/SafeMath.sol";
+import "@pancakeswap/pancake-swap-lib/contracts/utils/Address.sol";
+import "./interface/IMooniswap.sol";
+import "./interface/IFarmingRewardsV2.sol";
+
+import "../../base/interface/pancakeswap/IPancakeRouter02.sol";
+import "../../base/interface/IVault.sol";
+
+import "../../base/StrategyBase.sol";
+
+/**
+* This strategy is for 1INCH / X 1inch LP tokens
+* 1INCH must be token0, and the other token is denoted X
+*/
+contract OneInchStrategy_1INCH_renBTC is StrategyBase {
+
+  using SafeBEP20 for IBEP20;
+  using Address for address;
+  using SafeMath for uint256;
+
+  event Liquidating(address token, uint256 amount);
+  event ProfitsNotCollected(address token);
+
+  address public pool;
+  address public oneInch = address(0x111111111117dC0aa78b770fA6A738034120C302);
+  address public renBTC = address(0xfCe146bF3146100cfe5dB4129cf6C82b0eF4Ad8c);
+
+  uint256 maxUint = uint256(~0);
+  address public oneInchEthLP;
+
+  // token0 is ONEINCH
+  address public token1;
+
+  uint256 slippageNumerator = 9;
+  uint256 slippageDenominator = 10;
+
+  // a flag for disabling selling for simplified emergency exit
+  bool public sell = true;
+  // minimum 1inch amount to be liquidation
+  uint256 public sellFloorOneInch = 1e17;
+
+  constructor(
+    address _storage,
+    address _vault,
+    address _underlying,
+    address _pool
+  )
+  StrategyBase(_storage, _underlying, _vault, oneInch, address(0)) public {
+    require(IVault(_vault).underlying() == _underlying, "vault does not support the required LP token");
+    token1 = IMooniswap(_underlying).token1();
+    pool = _pool;
+    require(token1 != address(0), "token1 must be non-zero");
+    require(IMooniswap(_underlying).token0() == oneInch, "token0 must be 1INCH");
+
+    // making 1inch reward token salvagable to be able to
+    // liquidate externally
+    unsalvagableTokens[oneInch] = false;
+    unsalvagableTokens[token1] = true;
+  }
+
+  function depositArbCheck() public view returns(bool) {
+    return true;
+  }
+
+  /**
+  * Salvages a token. We should not be able to salvage underlying.
+  */
+  function salvage(address recipient, address token, uint256 amount) public onlyGovernance {
+    // To make sure that governance cannot come in and take away the coins
+    require(!unsalvagableTokens[token], "token is defined as not salvageable");
+    IBEP20(token).safeTransfer(recipient, amount);
+  }
+
+  /**
+  * Withdraws underlying from the investment pool that mints crops.
+  */
+  function withdrawUnderlyingFromPool(uint256 amount) internal {
+    IFarmingRewardsV2(pool).withdraw(
+      MathUpgradeable.min(IFarmingRewardsV2(pool).balanceOf(address(this)), amount)
+    );
+  }
+
+  /**
+  * Withdraws the underlying tokens to the pool in the specified amount.
+  */
+  function withdrawToVault(uint256 amountUnderlying) external restricted {
+    withdrawUnderlyingFromPool(amountUnderlying);
+    require(IBEP20(underlying).balanceOf(address(this)) >= amountUnderlying, "insufficient balance for the withdrawal");
+    IBEP20(underlying).safeTransfer(vault, amountUnderlying);
+  }
+
+  /**
+  * Withdraws all the underlying tokens to the pool.
+  */
+  function withdrawAllToVault() external restricted {
+    claimAndLiquidate();
+    uint256 bal = IFarmingRewardsV2(pool).balanceOf(address(this));
+    if (bal != 0) {
+      withdrawUnderlyingFromPool(maxUint);
+    }
+    uint256 balance = IBEP20(underlying).balanceOf(address(this));
+    IBEP20(underlying).safeTransfer(vault, balance);
+  }
+
+  /**
+  * Invests all the underlying into the pool that mints crops (1inch)
+  */
+  function investAllUnderlying() public restricted {
+    uint256 underlyingBalance = IBEP20(underlying).balanceOf(address(this));
+    if (underlyingBalance > 0) {
+      IBEP20(underlying).safeApprove(pool, 0);
+      IBEP20(underlying).safeApprove(pool, underlyingBalance);
+      IFarmingRewardsV2(pool).stake(underlyingBalance);
+    }
+  }
+
+  /**
+  * Claims the 1Inch crop, converts it accordingly
+  */
+
+  function claimAndLiquidate() internal {
+    if (!sell) {
+      // Profits can be disabled for possible simplified and rapid exit
+      emit ProfitsNotCollected(oneInch);
+      return;
+    }
+    IFarmingRewardsV2(pool).getAllRewards();
+    uint256 oneInchBalance = IBEP20(oneInch).balanceOf(address(this));
+    uint256 renBTCBalance = IBEP20(renBTC).balanceOf(address(this));
+    // swap renBTC to 1INCH to notify rewards in 1INCH
+    uint256 amountOutMin = 1;
+    if (renBTCBalance != 0) {
+      IBEP20(renBTC).safeApprove(underlying, 0);
+      IBEP20(renBTC).safeApprove(underlying, renBTCBalance);
+
+      // with the remaining, half would be converted into the second token
+      IMooniswap(underlying).swap(renBTC, oneInch, renBTCBalance, amountOutMin, address(0));
+    }
+
+    oneInchBalance = IBEP20(oneInch).balanceOf(address(this));
+
+    if (oneInchBalance < sellFloorOneInch || oneInchBalance == 0) {
+      emit ProfitsNotCollected(oneInch);
+      return;
+    }
+
+    // share 30% of the 1INCH as a profit sharing reward
+    notifyProfitInRewardToken(oneInchBalance);
+
+    uint256 remainingBalance = IBEP20(oneInch).balanceOf(address(this));
+
+    IBEP20(oneInch).safeApprove(underlying, 0);
+    IBEP20(oneInch).safeApprove(underlying, remainingBalance.div(2));
+
+    // with the remaining, half would be converted into the second token
+    IMooniswap(underlying).swap(oneInch, token1, remainingBalance.div(2), amountOutMin, address(0));
+
+    uint256 oneInchAmount = IBEP20(oneInch).balanceOf(address(this));
+    uint256 token1Amount = IBEP20(token1).balanceOf(address(this));
+
+    IBEP20(oneInch).safeApprove(underlying, 0);
+    IBEP20(oneInch).safeApprove(underlying, oneInchAmount);
+    IBEP20(token1).safeApprove(underlying, 0);
+    IBEP20(token1).safeApprove(underlying, token1Amount);
+
+    // adding liquidity: ETH + token1
+    IMooniswap(underlying).deposit(
+      [oneInchAmount, token1Amount],
+      [oneInchAmount.mul(slippageNumerator).div(slippageDenominator),
+        token1Amount.mul(slippageNumerator).div(slippageDenominator)
+      ]
+    );
+  }
+
+  /**
+  * Claims and liquidates 1inch into underlying, and then invests all underlying.
+  */
+  function doHardWork() public restricted {
+    claimAndLiquidate();
+    investAllUnderlying();
+  }
+
+  /**
+  * Investing all underlying.
+  */
+  function investedUnderlyingBalance() public view returns (uint256) {
+    return IFarmingRewardsV2(pool).balanceOf(address(this)).add(
+      IBEP20(underlying).balanceOf(address(this))
+    );
+  }
+
+  /**
+  * Can completely disable claiming 1inch rewards and selling. Good for emergency withdraw in the
+  * simplest possible way.
+  */
+  function setSell(bool s) public onlyGovernance {
+    sell = s;
+  }
+
+  /**
+  * Sets the minimum amount of 1inch needed to trigger a sale.
+  */
+  function setSellFloorAndSlippages(uint256 _sellFloorOneInch, uint256 _slippageNumerator, uint256 _slippageDenominator) public onlyGovernance {
+    sellFloorOneInch = _sellFloorOneInch;
+    slippageNumerator = _slippageNumerator;
+    slippageDenominator = _slippageDenominator;
+  }
+}

--- a/contracts/strategies/1inch/interface/IFarmingRewards.sol
+++ b/contracts/strategies/1inch/interface/IFarmingRewards.sol
@@ -1,0 +1,9 @@
+pragma solidity 0.6.12;
+
+interface IFarmingRewards {
+    function balanceOf(address account) external view returns (uint256);
+    function stake(uint256 amount) external;
+    function withdraw(uint256 amount) external;
+    function exit() external;
+    function getReward() external;
+}

--- a/contracts/strategies/1inch/interface/IFarmingRewardsV2.sol
+++ b/contracts/strategies/1inch/interface/IFarmingRewardsV2.sol
@@ -1,0 +1,9 @@
+pragma solidity 0.6.12;
+
+interface IFarmingRewardsV2 {
+    function balanceOf(address account) external view returns (uint256);
+    function stake(uint256 amount) external;
+    function withdraw(uint256 amount) external;
+    function exit() external;
+    function getAllRewards() external;
+}

--- a/contracts/strategies/1inch/interface/IMooniswap.sol
+++ b/contracts/strategies/1inch/interface/IMooniswap.sol
@@ -1,0 +1,12 @@
+pragma solidity 0.6.12;
+
+interface IMooniswap {
+    function token0() external view returns (address);
+    function token1() external view returns (address);
+
+    function getTokens() external view returns(address[] memory tokens);
+    function tokens(uint256 i) external view returns(address);
+    function deposit(uint256[2] calldata maxAmounts, uint256[2] calldata minAmounts) external payable returns(uint256 fairSupply, uint256[2] memory receivedAmounts);
+    function swap(address src, address dst, uint256 amount, uint256 minReturn, address referral) external payable returns(uint256 result);
+    function withdraw(uint256 amount, uint256[] memory minReturns) external returns(uint256[2] memory withdrawnAmounts);
+}

--- a/contracts/strategies/venus/VenusVAIStrategyMainnet.sol
+++ b/contracts/strategies/venus/VenusVAIStrategyMainnet.sol
@@ -39,7 +39,7 @@ contract VenusVAIStrategyMainnet is BaseUpgradeableStrategy {
       _vault,
       address(0x0667Eed0a0aAb930af74a3dfeDD263A73994f216), //RewardPool
       venus,
-      300, // profit sharing numerator
+      80, // profit sharing numerator
       1000, // profit sharing denominator
       true, // sell
       1e16, // sell floor

--- a/test/1inch/1inch-bnb.js
+++ b/test/1inch/1inch-bnb.js
@@ -85,7 +85,7 @@ describe("BSC Mainnet 1INCH 1INCH/BNB", function() {
     });
 
     await strategy.setSellFloorAndSlippages(0, 1, 10, {from:governance});
-    await feeForwarder.setConversionPath(oneInchAddr, eth, [oneInchAddr, wbnb, eth], {from:governance});
+    await feeForwarder.setConversionPath(wbnb, eth, [wbnb, eth], {from:governance});
 
     // whale send underlying to farmers
     await setupBalance();

--- a/test/1inch/1inch-bnb.js
+++ b/test/1inch/1inch-bnb.js
@@ -1,0 +1,132 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const {
+  impersonates,
+  setupCoreProtocol,
+  depositVault,
+  swapBNBToToken,
+  addLiquidity
+} = require("../utilities/hh-utils.js");
+
+const { send } = require("@openzeppelin/test-helpers");
+const BigNumber = require("bignumber.js");
+const IBEP20 = artifacts.require("IBEP20");
+const IMooniswap = artifacts.require("IMooniswap");
+
+//const Strategy = artifacts.require("");
+const Strategy = artifacts.require("OneInchStrategyMainnet_1INCH_BNB");
+
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("BSC Mainnet 1INCH 1INCH/BNB", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+
+  // external setup
+  let wbnb = "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c";
+  let oneInchAddr = "0x111111111117dC0aa78b770fA6A738034120C302";
+  let eth = "0x2170Ed0880ac9A755fd29B2688956BD959F933F8";
+  let zeroAddr = "0x0000000000000000000000000000000000000000";
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+
+  async function setupExternalContracts() {
+    underlying = await IBEP20.at("0xdaF66c0B7e8E2FC76B15B07AD25eE58E04a66796");
+    console.log("Fetching Underlying at: ", underlying.address);
+  }
+
+  async function setupBalance(){
+    oneInch = await IBEP20.at(oneInchAddr);
+    pair = await IMooniswap.at(underlying.address);
+    await pair.swap(zeroAddr, oneInchAddr, "100" + "000000000000000000", 0, zeroAddr, {from: farmer1, value: "100" + "000000000000000000"})
+    farmerOneInchBalance = await oneInch.balanceOf(farmer1);
+    await oneInch.approve(pair.address, farmerOneInchBalance, {from: farmer1});
+    await pair.deposit(
+      ["100" + "000000000000000000", farmerOneInchBalance],
+      [0,0],
+      {
+        from: farmer1,
+        value: "100" + "000000000000000000"
+      }
+    );
+    farmerBalance = await underlying.balanceOf(farmer1);
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    accounts = await web3.eth.getAccounts();
+
+    farmer1 = accounts[1];
+
+    // impersonate accounts
+    await impersonates([governance]);
+
+    let etherGiver = accounts[9];
+    await send.ether(etherGiver, governance, "100" + "000000000000000000")
+
+    await setupExternalContracts();
+    [controller, vault, strategy,,feeForwarder] = await setupCoreProtocol({
+      "existingVaultAddress": null,
+      "strategyArtifact": Strategy,
+      "underlying": underlying,
+      "governance": governance,
+    });
+
+    await strategy.setSellFloorAndSlippages(0, 1, 10, {from:governance});
+    await feeForwarder.setConversionPath(oneInchAddr, eth, [oneInchAddr, wbnb, eth], {from:governance});
+
+    // whale send underlying to farmers
+    await setupBalance();
+  });
+
+  describe("Happy path", function() {
+    it("Farmer should earn money", async function() {
+      let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+
+      // Using half days is to simulate how we doHardwork in the real world
+      let hours = 10;
+      let blocksPerHour = 2400;
+      let oldSharePrice;
+      let newSharePrice;
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+
+        oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        await controller.doHardWork(vault.address, { from: governance });
+        newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+
+        console.log("old shareprice: ", oldSharePrice.toFixed());
+        console.log("new shareprice: ", newSharePrice.toFixed());
+        console.log("growth: ", newSharePrice.toFixed() / oldSharePrice.toFixed());
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+      await vault.withdraw(new BigNumber(await vault.balanceOf(farmer1)).toFixed(), { from: farmer1 });
+      let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      Utils.assertBNGt(farmerNewBalance, farmerOldBalance);
+
+      apr = (farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/1200))*365;
+      apy = ((farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/1200))+1)**365;
+
+      console.log("earned!");
+      console.log("APR:", apr*100, "%");
+      console.log("APY:", (apy-1)*100, "%");
+
+      await strategy.withdrawAllToVault({from:governance}); // making sure can withdraw all for a next switch
+
+    });
+  });
+});

--- a/test/1inch/1inch-renbtc.js
+++ b/test/1inch/1inch-renbtc.js
@@ -104,7 +104,7 @@ describe("BSC Mainnet 1INCH 1INCH/renBTC", function() {
     });
 
     await strategy.setSellFloorAndSlippages(0, 1, 10, {from:governance});
-    await feeForwarder.setConversionPath(oneInchAddr, eth, [oneInchAddr, wbnb, eth], {from:governance});
+    await feeForwarder.setConversionPath(wbnb, eth, [wbnb, eth], {from:governance});
 
     // whale send underlying to farmers
     await setupBalance();

--- a/test/1inch/1inch-renbtc.js
+++ b/test/1inch/1inch-renbtc.js
@@ -1,0 +1,151 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const {
+  impersonates,
+  setupCoreProtocol,
+  depositVault,
+  swapBNBToToken,
+  addLiquidity
+} = require("../utilities/hh-utils.js");
+
+const { send } = require("@openzeppelin/test-helpers");
+const BigNumber = require("bignumber.js");
+const IBEP20 = artifacts.require("IBEP20");
+const IMooniswap = artifacts.require("IMooniswap");
+
+//const Strategy = artifacts.require("");
+const Strategy = artifacts.require("OneInchStrategyMainnet_1INCH_renBTC");
+
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("BSC Mainnet 1INCH 1INCH/renBTC", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+
+  // external setup
+  let wbnb = "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c";
+  let oneInchBNBPoolAddr = "0xdaF66c0B7e8E2FC76B15B07AD25eE58E04a66796";
+  let oneInchAddr = "0x111111111117dC0aa78b770fA6A738034120C302";
+  let renBTCAddr = "0xfCe146bF3146100cfe5dB4129cf6C82b0eF4Ad8c";
+  let eth = "0x2170Ed0880ac9A755fd29B2688956BD959F933F8";
+  let zeroAddr = "0x0000000000000000000000000000000000000000";
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+
+  async function setupExternalContracts() {
+    underlying = await IBEP20.at("0xe3f6509818ccf031370bB4cb398EB37C21622ac4");
+    console.log("Fetching Underlying at: ", underlying.address);
+  }
+
+  async function setupBalance(){
+    oneInch = await IBEP20.at(oneInchAddr);
+    renBTC = await IBEP20.at(renBTCAddr);
+    oneInchBNBPool = await IMooniswap.at(oneInchBNBPoolAddr);
+    pair = await IMooniswap.at(underlying.address);
+    await oneInchBNBPool.swap(
+      zeroAddr,
+      oneInchAddr,
+      "1000" + "000000000000000000",
+      0,
+      zeroAddr,
+      {
+        from: farmer1,
+        value: "1000" + "000000000000000000"
+      }
+    );
+    farmerOneInchBalance = await oneInch.balanceOf(farmer1);
+    toSwap = new BigNumber(farmerOneInchBalance/2);
+    await oneInch.approve(pair.address, toSwap, {from: farmer1});
+    await pair.swap(oneInchAddr, renBTCAddr, toSwap, 0 , zeroAddr, {from: farmer1});
+    farmerOneInchBalance = await oneInch.balanceOf(farmer1);
+    farmerRenBTCBalance = await renBTC.balanceOf(farmer1);
+    await oneInch.approve(pair.address, farmerOneInchBalance, {from: farmer1});
+    await renBTC.approve(pair.address, farmerRenBTCBalance, {from: farmer1});
+    await pair.deposit(
+      [farmerOneInchBalance, farmerRenBTCBalance],
+      [0,0],
+      {
+        from: farmer1
+      }
+    );
+    farmerBalance = await underlying.balanceOf(farmer1);
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    accounts = await web3.eth.getAccounts();
+
+    farmer1 = accounts[1];
+
+    // impersonate accounts
+    await impersonates([governance]);
+
+    let etherGiver = accounts[9];
+    await send.ether(etherGiver, governance, "100" + "000000000000000000")
+
+    await setupExternalContracts();
+    [controller, vault, strategy,,feeForwarder] = await setupCoreProtocol({
+      "existingVaultAddress": null,
+      "strategyArtifact": Strategy,
+      "underlying": underlying,
+      "governance": governance,
+    });
+
+    await strategy.setSellFloorAndSlippages(0, 1, 10, {from:governance});
+    await feeForwarder.setConversionPath(oneInchAddr, eth, [oneInchAddr, wbnb, eth], {from:governance});
+
+    // whale send underlying to farmers
+    await setupBalance();
+  });
+
+  describe("Happy path", function() {
+    it("Farmer should earn money", async function() {
+      let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+
+      // Using half days is to simulate how we doHardwork in the real world
+      let hours = 10;
+      let blocksPerHour = 2400;
+      let oldSharePrice;
+      let newSharePrice;
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+
+        oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        await controller.doHardWork(vault.address, { from: governance });
+        newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+
+        console.log("old shareprice: ", oldSharePrice.toFixed());
+        console.log("new shareprice: ", newSharePrice.toFixed());
+        console.log("growth: ", newSharePrice.toFixed() / oldSharePrice.toFixed());
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+      await vault.withdraw(new BigNumber(await vault.balanceOf(farmer1)).toFixed(), { from: farmer1 });
+      let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      Utils.assertBNGt(farmerNewBalance, farmerOldBalance);
+
+      apr = (farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/1200))*365;
+      apy = ((farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/1200))+1)**365;
+
+      console.log("earned!");
+      console.log("APR:", apr*100, "%");
+      console.log("APY:", (apy-1)*100, "%");
+
+      await strategy.withdrawAllToVault({from:governance}); // making sure can withdraw all for a next switch
+
+    });
+  });
+});


### PR DESCRIPTION
1INCH currently has 2 active [LP farms](https://1inch.exchange/#/dao/farming?network=56) on BSC. I made strategies for both. Liquidation is a bit of a struggle, because both 1INCH and renBTC do not have any other liquidity than the 1INCH pools on BSC. What I did is have both strategies notify reward in wBNB, so we can swap that to ETH on Pancakeswap. The renBTC pool gets both 1INCH and renBTC rewards, so liquidation there looks like: `renBTC -> 1INCH -> BNB -> (notify wBNB) -> 1INCH -> 1/2 renBTC -> deposit in LP`. So bit of a long route, could make it more efficient when integrating a universal liquidator that would be able to liquidate on 1INCH as well. No big problem for now I think.

The pools have been active for only 1/2 days and will be active for a total of 28 days. Knowing 1INCH they might be extended of course. Test results below:

1INCH-BNB `test/1inch/1inch-bnb.js`
```
  BSC Mainnet 1INCH 1INCH/BNB
Impersonating...
0xf00dD244228F51547f0563e60bCa65a30FBF5f7f
Fetching Underlying at:  0xdaF66c0B7e8E2FC76B15B07AD25eE58E04a66796
New Vault Deployed:  0xc5dDD0986caeB7fb7fc1556712Af141E9E6A83cA
Strategy Deployed:  0xf465573288D9D89C6E89b1bc3BC9ce2b997E77dF
Strategy and vault added to Controller.
    Happy path
loop  0
old shareprice:  1000000000000000000
new shareprice:  1000000000000000000
growth:  1
loop  1
old shareprice:  1000000000000000000
new shareprice:  1000493415430842891
growth:  1.000493415430843
loop  2
old shareprice:  1000493415430842891
new shareprice:  1000987947571363041
growth:  1.00049428825107
loop  3
old shareprice:  1000987947571363041
new shareprice:  1001482673498397998
growth:  1.0004942376461528
loop  4
old shareprice:  1001482673498397998
new shareprice:  1001977629451844540
growth:  1.0004942231818326
loop  5
old shareprice:  1001977629451844540
new shareprice:  1002472828005454089
growth:  1.0004942211672734
loop  6
old shareprice:  1002472828005454089
new shareprice:  1002968281933246190
growth:  1.0004942317776113
loop  7
old shareprice:  1002968281933246190
new shareprice:  1003463965486635073
growth:  1.0004942165792456
loop  8
old shareprice:  1003463965486635073
new shareprice:  1003959891533620809
growth:  1.0004942141063782
loop  9
old shareprice:  1003959891533620809
new shareprice:  1004456073069051706
growth:  1.0004942244601753
earned!
APR: 216.9188175496851 %
APY: 769.5171553068814 %
      √ Farmer should earn money (41037ms)


  1 passing (54s)
```

1INCH-renBTC `test/1inch/1inch-renbtc.js`
```
  BSC Mainnet 1INCH 1INCH/renBTC
Impersonating...
0xf00dD244228F51547f0563e60bCa65a30FBF5f7f
Fetching Underlying at:  0xe3f6509818ccf031370bB4cb398EB37C21622ac4
New Vault Deployed:  0xc5dDD0986caeB7fb7fc1556712Af141E9E6A83cA
Strategy Deployed:  0xf465573288D9D89C6E89b1bc3BC9ce2b997E77dF
Strategy and vault added to Controller.
    Happy path
loop  0
old shareprice:  1000000000000000000
new shareprice:  1000000000000000000
growth:  1
loop  1
old shareprice:  1000000000000000000
new shareprice:  1000235980975418530
growth:  1.0002359809754184
loop  2
old shareprice:  1000235980975418530
new shareprice:  1000472454021614616
growth:  1.0002364172562215
loop  3
old shareprice:  1000472454021614616
new shareprice:  1000708967865558487
growth:  1.0002364021547951
loop  4
old shareprice:  1000708967865558487
new shareprice:  1000945531020613906
growth:  1.000236395558201
loop  5
old shareprice:  1000945531020613906
new shareprice:  1001182151999947859
growth:  1.000236397458204
loop  6
old shareprice:  1001182151999947859
new shareprice:  1001418830802514412
growth:  1.0002363993426109
loop  7
old shareprice:  1001418830802514412
new shareprice:  1001655558912664879
growth:  1.0002363927088935
loop  8
old shareprice:  1001655558912664879
new shareprice:  1001892344843590206
growth:  1.000236394565795
loop  9
old shareprice:  1001892344843590206
new shareprice:  1002129180079768664
growth:  1.0002363879087384
earned!
APR: 103.63363035913635 %
APY: 181.4734270048482 %
      √ Farmer should earn money (43724ms)


  1 passing (1m)
```