### PR TITLE
Fixed problem with notifying deposits for vaults where underlying = rewardToken

### DIFF
--- a/contracts/base/masterchef/GeneralMasterChefStrategy.sol
+++ b/contracts/base/masterchef/GeneralMasterChefStrategy.sol
@@ -121,8 +121,7 @@ contract GeneralMasterChefStrategy is BaseUpgradeableStrategy {
   }
 
   // We assume that all the tradings can be done on Pancakeswap
-  function _liquidateReward() internal {
-    uint256 rewardBalance = IBEP20(rewardToken()).balanceOf(address(this));
+  function _liquidateReward(uint256 rewardBalance) internal {
     if (!sell() || rewardBalance < sellFloor()) {
       // Profits can be disabled for possible simplified and rapid exit
       emit ProfitsNotCollected(sell(), rewardBalance < sellFloor());
@@ -235,7 +234,8 @@ contract GeneralMasterChefStrategy is BaseUpgradeableStrategy {
       IMasterChef(rewardPool()).withdraw(poolId(), bal);
     }
     if (underlying() != rewardToken()) {
-      _liquidateReward();
+      uint256 rewardBalance = IBEP20(rewardToken()).balanceOf(address(this));
+      _liquidateReward(rewardBalance);
     }
     IBEP20(underlying()).safeTransfer(vault(), IBEP20(underlying()).balanceOf(address(this)));
   }
@@ -295,8 +295,11 @@ contract GeneralMasterChefStrategy is BaseUpgradeableStrategy {
   function doHardWork() external onlyNotPausedInvesting restricted {
     uint256 bal = rewardPoolBalance();
     if (bal != 0) {
+      uint256 rewardBalanceBefore = IBEP20(rewardToken()).balanceOf(address(this));
       IMasterChef(rewardPool()).withdraw(poolId(), 0);
-      _liquidateReward();
+      uint256 rewardBalanceAfter = IBEP20(rewardToken()).balanceOf(address(this));
+      uint256 claimedReward = rewardBalanceAfter.sub(rewardBalanceBefore);
+      _liquidateReward(claimedReward);
     }
 
     investAllUnderlying();

--- a/contracts/base/pancake-base/PancakeMasterChefStrategy.sol
+++ b/contracts/base/pancake-base/PancakeMasterChefStrategy.sol
@@ -141,8 +141,7 @@ contract PancakeMasterChefStrategy is BaseUpgradeableStrategy {
   }
 
   // We assume that all the tradings can be done on Pancakeswap
-  function _liquidateReward() internal {
-    uint256 rewardBalance = IBEP20(rewardToken()).balanceOf(address(this));
+  function _liquidateReward(uint256 rewardBalance) internal {
     if (!sell() || rewardBalance < sellFloor()) {
       // Profits can be disabled for possible simplified and rapid exit
       emit ProfitsNotCollected(sell(), rewardBalance < sellFloor());
@@ -255,7 +254,8 @@ contract PancakeMasterChefStrategy is BaseUpgradeableStrategy {
       exitRewardPool(bal);
     }
     if (underlying() != rewardToken()) {
-      _liquidateReward();
+      uint256 rewardBalance = IBEP20(rewardToken()).balanceOf(address(this));
+      _liquidateReward(rewardBalance);
     }
     IBEP20(underlying()).safeTransfer(vault(), IBEP20(underlying()).balanceOf(address(this)));
   }
@@ -315,8 +315,11 @@ contract PancakeMasterChefStrategy is BaseUpgradeableStrategy {
   function doHardWork() external onlyNotPausedInvesting restricted {
     uint256 bal = rewardPoolBalance();
     if (bal != 0) {
+      uint256 rewardBalanceBefore = IBEP20(rewardToken()).balanceOf(address(this));
       _claimReward();
-      _liquidateReward();
+      uint256 rewardBalanceAfter = IBEP20(rewardToken()).balanceOf(address(this));
+      uint256 claimedReward = rewardBalanceAfter.sub(rewardBalanceBefore);
+      _liquidateReward(claimedReward);
     }
 
     investAllUnderlying();

--- a/test/pancakeswap/cake.js
+++ b/test/pancakeswap/cake.js
@@ -28,6 +28,7 @@ describe("BSC Mainnet Pancake CAKE", function() {
   // parties in the protocol
   let governance;
   let farmer1;
+  let farmer2;
 
   // numbers used in tests
   let farmerBalance;
@@ -44,7 +45,10 @@ describe("BSC Mainnet Pancake CAKE", function() {
 
   async function setupBalance(){
     await swapBNBToToken(farmer1, [wbnb, underlying.address], "100" + "000000000000000000");
-    farmerBalance = await underlying.balanceOf(farmer1);
+    farmer1Balance = await underlying.balanceOf(farmer1);
+    await swapBNBToToken(farmer2, [wbnb, underlying.address], "100" + "000000000000000000");
+    farmer2Balance = await underlying.balanceOf(farmer2);
+
   }
 
   before(async function() {
@@ -52,6 +56,7 @@ describe("BSC Mainnet Pancake CAKE", function() {
     accounts = await web3.eth.getAccounts();
 
     farmer1 = accounts[1];
+    farmer2 = accounts[2];
 
     // impersonate accounts
     await impersonates([governance]);
@@ -75,7 +80,7 @@ describe("BSC Mainnet Pancake CAKE", function() {
   describe("Happy path", function() {
     it("Farmer should earn money", async function() {
       let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
-      await depositVault(farmer1, underlying, vault, farmerBalance);
+      await depositVault(farmer1, underlying, vault, farmer1Balance);
 
       // Using half days is to simulate how we doHardwork in the real world
       let hours = 10;
@@ -83,6 +88,9 @@ describe("BSC Mainnet Pancake CAKE", function() {
       let oldSharePrice;
       let newSharePrice;
       for (let i = 0; i < hours; i++) {
+        if (i==1) {
+          await depositVault(farmer2, underlying, vault, farmer2Balance);
+        }
         console.log("loop ", i);
 
         oldSharePrice = new BigNumber(await vault.getPricePerFullShare());


### PR DESCRIPTION
Cake vault is notifying new deposits as reward, taking the PS fee of deposits: [doHardWork call].(https://bscscan.com/tx/0xc9141d0c71d3afe6a13ea040bfb8be0c820239606ca24f82b0d0858b87442eac)

I made a fix that checks the difference in rewardToken balance before and after claiming the reward. I tested it by adding a second farmer to the test that deposits in the second loop and it works. Below are test logs for the old case and the fix to illustrate the difference. I also added the fix to the `GeneralMasterChefStrategy`.

This new strategy should be deployed to the CAKE vault ASAP and doHardWork should not be run again on the vault before the new strategy is set.

Old situation:
```
  BSC Mainnet Pancake CAKE
Impersonating...
0xf00dD244228F51547f0563e60bCa65a30FBF5f7f
Fetching Underlying at:  0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82
New Vault Deployed:  0x9090BCcD472b9D11DE302572167DED6632e185AB
Strategy Deployed:  0x322813Fd9A801c5507c9de605d63CEA4f2CE6c44
Strategy and vault added to Controller.
    Happy path
loop  0
old shareprice:  1000000000000000000
new shareprice:  1000000000000000000
growth:  1
loop  1
old shareprice:  1000000000000000000
new shareprice:  960117375818515839
growth:  0.9601173758185159
loop  2
old shareprice:  960117375818515839
new shareprice:  960354086163437757
growth:  1.000246543132
loop  3
old shareprice:  960354086163437757
new shareprice:  960590854865748780
growth:  1.00024654313
loop  4
old shareprice:  960590854865748780
new shareprice:  960827681939835576
growth:  1.000246543128
loop  5
old shareprice:  960827681939835576
new shareprice:  961064567400088357
growth:  1.000246543126
loop  6
old shareprice:  961064567400088357
new shareprice:  961301511260900883
growth:  1.000246543124
loop  7
old shareprice:  961301511260900883
new shareprice:  961538513535709162
growth:  1.0002465431210001
loop  8
old shareprice:  961538513535709162
new shareprice:  961775574239874880
growth:  1.000246543119
loop  9
old shareprice:  961775574239874880
new shareprice:  962012693387802444
growth:  1.0002465431170002
      1) Farmer should earn money


  0 passing (1m)
  1 failing
```

With fix:
```
  BSC Mainnet Pancake CAKE
Impersonating...
0xf00dD244228F51547f0563e60bCa65a30FBF5f7f
Fetching Underlying at:  0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82
New Vault Deployed:  0x9090BCcD472b9D11DE302572167DED6632e185AB
Strategy Deployed:  0x322813Fd9A801c5507c9de605d63CEA4f2CE6c44
Strategy and vault added to Controller.
    Happy path
loop  0
old shareprice:  1000000000000000000
new shareprice:  1000000000000000000
growth:  1
loop  1
old shareprice:  1000000000000000000
new shareprice:  1000123381811565485
growth:  1.0001233818115653
loop  2
old shareprice:  1000123381811565485
new shareprice:  1000369942234884230
growth:  1.000246530006
loop  3
old shareprice:  1000369942234884230
new shareprice:  1000616563440744876
growth:  1.000246530004
loop  4
old shareprice:  1000616563440744876
new shareprice:  1000863245443130539
growth:  1.000246530001
loop  5
old shareprice:  1000863245443130539
new shareprice:  1001109988258028771
growth:  1.000246529999
loop  6
old shareprice:  1001109988258028771
new shareprice:  1001356791900430693
growth:  1.000246529997
loop  7
old shareprice:  1001356791900430693
new shareprice:  1001603656385331122
growth:  1.0002465299949999
loop  8
old shareprice:  1001603656385331122
new shareprice:  1001850581727728572
growth:  1.000246529993
loop  9
old shareprice:  1001850581727728572
new shareprice:  1002097567941623403
growth:  1.00024652999
earned!
APR: 96.70892194010591 %
APY: 162.69153779049884 %
      √ Farmer should earn money (41437ms)


  1 passing (1m)
```