### PR TITLE
Fix compile warnings

### DIFF
--- a/contracts/base/Vault.sol
+++ b/contracts/base/Vault.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "@openzeppelin/contracts-upgradeable/math/MathUpgradeable.sol";

--- a/contracts/base/VaultProxy.sol
+++ b/contracts/base/VaultProxy.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "./interface/IUpgradeSource.sol";
@@ -20,7 +22,7 @@ contract VaultProxy is BaseUpgradeabilityProxy {
 
     // the finalization needs to be executed on itself to update the storage of this proxy
     // it also needs to be invoked by the governance, not by address(this), so delegatecall is needed
-    (bool success, bytes memory result) = address(this).delegatecall(
+    (bool success,) = address(this).delegatecall(
       abi.encodeWithSignature("finalizeUpgrade()")
     );
 

--- a/contracts/base/VaultStorage.sol
+++ b/contracts/base/VaultStorage.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol";

--- a/contracts/base/inheritance/Controllable.sol
+++ b/contracts/base/inheritance/Controllable.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "./Governable.sol";

--- a/contracts/base/inheritance/ControllableInit.sol
+++ b/contracts/base/inheritance/ControllableInit.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "./GovernableInit.sol";

--- a/contracts/base/inheritance/Governable.sol
+++ b/contracts/base/inheritance/Governable.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "./Storage.sol";

--- a/contracts/base/inheritance/GovernableInit.sol
+++ b/contracts/base/inheritance/GovernableInit.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol";

--- a/contracts/base/inheritance/IUpgradeSource.sol
+++ b/contracts/base/inheritance/IUpgradeSource.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 interface IUpgradeSource {

--- a/contracts/base/inheritance/RewardTokenProfitNotifier.sol
+++ b/contracts/base/inheritance/RewardTokenProfitNotifier.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "@pancakeswap/pancake-swap-lib/contracts/math/SafeMath.sol";

--- a/contracts/base/inheritance/Storage.sol
+++ b/contracts/base/inheritance/Storage.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 contract Storage {

--- a/contracts/base/interface/IController.sol
+++ b/contracts/base/interface/IController.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 interface IController {

--- a/contracts/base/interface/IFeeRewardForwarder.sol
+++ b/contracts/base/interface/IFeeRewardForwarder.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 interface IFeeRewardForwarder {

--- a/contracts/base/interface/IRewardPool.sol
+++ b/contracts/base/interface/IRewardPool.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 // Unifying the interface with the Synthetix Reward Pool

--- a/contracts/base/interface/IStrategy.sol
+++ b/contracts/base/interface/IStrategy.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 interface IStrategy {

--- a/contracts/base/interface/IUpgradeSource.sol
+++ b/contracts/base/interface/IUpgradeSource.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 interface IUpgradeSource {

--- a/contracts/base/interface/IVault.sol
+++ b/contracts/base/interface/IVault.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 interface IVault {

--- a/contracts/base/masterchef/GeneralMasterChefStrategy.sol
+++ b/contracts/base/masterchef/GeneralMasterChefStrategy.sol
@@ -76,7 +76,7 @@ contract GeneralMasterChefStrategy is BaseUpgradeableStrategy {
     setBoolean(_IS_LP_ASSET_SLOT, _isLpToken);
   }
 
-  function depositArbCheck() public view returns(bool) {
+  function depositArbCheck() public pure returns(bool) {
     return true;
   }
 

--- a/contracts/base/pancake-base/PancakeMasterChefStrategy.sol
+++ b/contracts/base/pancake-base/PancakeMasterChefStrategy.sol
@@ -76,7 +76,7 @@ contract PancakeMasterChefStrategy is BaseUpgradeableStrategy {
     setBoolean(_IS_LP_ASSET_SLOT, _isLpToken);
   }
 
-  function depositArbCheck() public view returns(bool) {
+  function depositArbCheck() public pure returns(bool) {
     return true;
   }
 

--- a/contracts/base/upgradability/BaseUpgradeableStrategyStorage.sol
+++ b/contracts/base/upgradability/BaseUpgradeableStrategyStorage.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol";

--- a/contracts/base/upgradability/Proxy.sol
+++ b/contracts/base/upgradability/Proxy.sol
@@ -18,6 +18,8 @@ abstract contract Proxy {
     _fallback();
   }
 
+  receive () payable external {}
+
   /**
    * @return The Address of the implementation.
    */

--- a/contracts/base/upgradability/Proxy.sol
+++ b/contracts/base/upgradability/Proxy.sol
@@ -1,4 +1,3 @@
-
 // SPDX-License-Identifier: MIT
 
 pragma solidity 0.6.12;

--- a/contracts/base/upgradability/StrategyProxy.sol
+++ b/contracts/base/upgradability/StrategyProxy.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "../inheritance/IUpgradeSource.sol";
@@ -20,7 +22,7 @@ contract StrategyProxy is BaseUpgradeabilityProxy {
 
     // the finalization needs to be executed on itself to update the storage of this proxy
     // it also needs to be invoked by the governance, not by address(this), so delegatecall is needed
-    (bool success, bytes memory result) = address(this).delegatecall(
+    (bool success,) = address(this).delegatecall(
       abi.encodeWithSignature("finalizeUpgrade()")
     );
 

--- a/contracts/base/venus-base/VenusFoldStrategy.sol
+++ b/contracts/base/venus-base/VenusFoldStrategy.sol
@@ -81,7 +81,7 @@ contract VenusFoldStrategy is BaseUpgradeableStrategy, VenusInteractorInitializa
     borrowedInUnderlying = CompleteVToken(vToken()).borrowBalanceCurrent(address(this));
   }
 
-  function depositArbCheck() public view returns (bool) {
+  function depositArbCheck() public pure returns (bool) {
     // there's no arb here.
     return true;
   }

--- a/contracts/base/venus-base/VenusInteractor.sol
+++ b/contracts/base/venus-base/VenusInteractor.sol
@@ -56,7 +56,7 @@ contract VenusInteractor is ReentrancyGuardUpgradeable {
     }
     WBNB wbnb = WBNB(payable(address(_wbnb)));
     wbnb.withdraw(balance); // Unwrapping
-    IVBNB(address(vtoken)).mint.value(balance)();
+    IVBNB(address(vtoken)).mint{value: balance}();
   }
 
   /**
@@ -66,7 +66,7 @@ contract VenusInteractor is ReentrancyGuardUpgradeable {
   function _redeemBNBInvTokens(uint256 amountVTokens) internal nonReentrant {
     _redeemInVTokens(amountVTokens);
     WBNB wbnb = WBNB(payable(address(_wbnb)));
-    wbnb.deposit.value(address(this).balance)();
+    wbnb.deposit{value: address(this).balance}();
   }
 
   /**
@@ -101,7 +101,7 @@ contract VenusInteractor is ReentrancyGuardUpgradeable {
     uint256 result = vtoken.borrow(amountUnderlying);
     require(result == 0, "Borrow failed");
     WBNB wbnb = WBNB(payable(address(_wbnb)));
-    wbnb.deposit.value(address(this).balance)();
+    wbnb.deposit{value: address(this).balance}();
   }
 
   /**
@@ -120,7 +120,7 @@ contract VenusInteractor is ReentrancyGuardUpgradeable {
   function _repayInWBNB(uint256 amountUnderlying) internal {
     WBNB wbnb = WBNB(payable(address(_wbnb)));
     wbnb.withdraw(amountUnderlying); // Unwrapping
-    IVBNB(address(vtoken)).repayBorrow.value(amountUnderlying)();
+    IVBNB(address(vtoken)).repayBorrow{value: amountUnderlying}();
   }
 
   /**
@@ -148,7 +148,7 @@ contract VenusInteractor is ReentrancyGuardUpgradeable {
     if (amountUnderlying > 0) {
       _redeemUnderlying(amountUnderlying);
       WBNB wbnb = WBNB(payable(address(_wbnb)));
-      wbnb.deposit.value(address(this).balance)();
+      wbnb.deposit{value: address(this).balance}();
     }
   }
 

--- a/contracts/base/venus-base/VenusInteractorInitializable.sol
+++ b/contracts/base/venus-base/VenusInteractorInitializable.sol
@@ -64,7 +64,7 @@ contract VenusInteractorInitializable is Initializable, ReentrancyGuardUpgradeab
     }
     WBNB wbnb = WBNB(payable(_wbnb));
     wbnb.withdraw(balance); // Unwrapping
-    IVBNB(vToken()).mint.value(balance)();
+    IVBNB(vToken()).mint{value: balance}();
   }
 
   /**
@@ -74,7 +74,7 @@ contract VenusInteractorInitializable is Initializable, ReentrancyGuardUpgradeab
   function _redeemBNBInvTokens(uint256 amountVTokens) internal nonReentrant {
     _redeemInVTokens(amountVTokens);
     WBNB wbnb = WBNB(payable(_wbnb));
-    wbnb.deposit.value(address(this).balance)();
+    wbnb.deposit{value: address(this).balance}();
   }
 
   /**
@@ -109,7 +109,7 @@ contract VenusInteractorInitializable is Initializable, ReentrancyGuardUpgradeab
     uint256 result = CompleteVToken(vToken()).borrow(amountUnderlying);
     require(result == 0, "Borrow failed");
     WBNB wbnb = WBNB(payable(_wbnb));
-    wbnb.deposit.value(address(this).balance)();
+    wbnb.deposit{value: address(this).balance}();
   }
 
   /**
@@ -128,7 +128,7 @@ contract VenusInteractorInitializable is Initializable, ReentrancyGuardUpgradeab
   function _repayInWBNB(uint256 amountUnderlying) internal {
     WBNB wbnb = WBNB(payable(_wbnb));
     wbnb.withdraw(amountUnderlying); // Unwrapping
-    IVBNB(vToken()).repayBorrow.value(amountUnderlying)();
+    IVBNB(vToken()).repayBorrow{value: amountUnderlying}();
   }
 
   /**
@@ -156,7 +156,7 @@ contract VenusInteractorInitializable is Initializable, ReentrancyGuardUpgradeab
     if (amountUnderlying > 0) {
       _redeemUnderlying(amountUnderlying);
       WBNB wbnb = WBNB(payable(_wbnb));
-      wbnb.deposit.value(address(this).balance)();
+      wbnb.deposit{value: address(this).balance}();
     }
   }
 

--- a/contracts/base/venus-base/VenusWBNBFoldStrategy.sol
+++ b/contracts/base/venus-base/VenusWBNBFoldStrategy.sol
@@ -80,7 +80,7 @@ contract VenusWBNBFoldStrategy is BaseUpgradeableStrategy, VenusInteractorInitia
     borrowedInUnderlying = CompleteVToken(vToken()).borrowBalanceCurrent(address(this));
   }
 
-  function depositArbCheck() public view returns (bool) {
+  function depositArbCheck() public pure returns (bool) {
     // there's no arb here.
     return true;
   }

--- a/contracts/base/venus-base/interface/IVAIVault.sol
+++ b/contracts/base/venus-base/interface/IVAIVault.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.6.0;
+pragma solidity 0.6.12;
 
 // https://bscscan.com/address/0x7680c89eb3e58dec4d38093b4803be2b7f257360#code
 interface IVAIVault {

--- a/contracts/base/venus-base/interface/VTokenInterfaces.sol
+++ b/contracts/base/venus-base/interface/VTokenInterfaces.sol
@@ -27,13 +27,13 @@ abstract contract VTokenStorage {
     uint8 public decimals;
 
     /**
-     * @notice Maximum borrow rate that can ever be applied (.0005% / block)
+     * @dev Maximum borrow rate that can ever be applied (.0005% / block)
      */
 
     uint internal constant borrowRateMaxMantissa = 0.0005e16;
 
     /**
-     * @notice Maximum fraction of interest that can be set aside for reserves
+     * @dev Maximum fraction of interest that can be set aside for reserves
      */
     uint internal constant reserveFactorMaxMantissa = 1e18;
 
@@ -58,7 +58,7 @@ abstract contract VTokenStorage {
     InterestRateModel public interestRateModel;
 
     /**
-     * @notice Initial exchange rate used when minting the first VTokens (used when totalSupply = 0)
+     * @dev Initial exchange rate used when minting the first VTokens (used when totalSupply = 0)
      */
     uint internal initialExchangeRateMantissa;
 
@@ -93,12 +93,12 @@ abstract contract VTokenStorage {
     uint public totalSupply;
 
     /**
-     * @notice Official record of token balances for each account
+     * @dev Official record of token balances for each account
      */
     mapping (address => uint) internal accountTokens;
 
     /**
-     * @notice Approved token transfer amounts on behalf of others
+     * @dev Approved token transfer amounts on behalf of others
      */
     mapping (address => mapping (address => uint)) internal transferAllowances;
 
@@ -113,7 +113,7 @@ abstract contract VTokenStorage {
     }
 
     /**
-     * @notice Mapping of account addresses to outstanding borrow balances
+     * @dev Mapping of account addresses to outstanding borrow balances
      */
     mapping(address => BorrowSnapshot) internal accountBorrows;
 }

--- a/contracts/strategies/1inch/OneInchStrategyMainnet_1INCH_BNB.sol
+++ b/contracts/strategies/1inch/OneInchStrategyMainnet_1INCH_BNB.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "./OneInchStrategy_1INCH_BNB.sol";

--- a/contracts/strategies/1inch/OneInchStrategyMainnet_1INCH_renBTC.sol
+++ b/contracts/strategies/1inch/OneInchStrategyMainnet_1INCH_renBTC.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "./OneInchStrategy_1INCH_renBTC.sol";

--- a/contracts/strategies/1inch/OneInchStrategy_1INCH_BNB.sol
+++ b/contracts/strategies/1inch/OneInchStrategy_1INCH_BNB.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "@pancakeswap/pancake-swap-lib/contracts/token/BEP20/IBEP20.sol";
@@ -63,7 +65,7 @@ contract OneInchStrategy_1INCH_BNB is StrategyBase {
     unsalvagableTokens[oneInch] = false;
   }
 
-  function depositArbCheck() public view returns(bool) {
+  function depositArbCheck() public pure returns(bool) {
     return true;
   }
 
@@ -145,7 +147,7 @@ contract OneInchStrategy_1INCH_BNB is StrategyBase {
 
     uint256 bnbBalance = address(this).balance;
     WBNB wbnb = WBNB(payable(_wbnb));
-    wbnb.deposit.value(bnbBalance)();
+    wbnb.deposit{value: bnbBalance}();
 
     // share 30% of the 1INCH as a profit sharing reward
     notifyProfitInRewardToken(bnbBalance);
@@ -153,7 +155,7 @@ contract OneInchStrategy_1INCH_BNB is StrategyBase {
     uint256 remainingBalance = IBEP20(_wbnb).balanceOf(address(this));
 
     wbnb.withdraw(remainingBalance);
-    IMooniswap(underlying).swap.value(remainingBalance.div(2))(
+    IMooniswap(underlying).swap{value: remainingBalance.div(2)}(
       address(0),
       oneInch,
       remainingBalance.div(2),
@@ -168,7 +170,7 @@ contract OneInchStrategy_1INCH_BNB is StrategyBase {
     IBEP20(oneInch).safeApprove(underlying, oneInchAmount);
 
     // adding liquidity: ETH + token1
-    IMooniswap(underlying).deposit.value(bnbAmount)(
+    IMooniswap(underlying).deposit{value: bnbAmount}(
       [bnbAmount, oneInchAmount],
       [bnbAmount.mul(slippageNumerator).div(slippageDenominator),
         oneInchAmount.mul(slippageNumerator).div(slippageDenominator)

--- a/contracts/strategies/1inch/OneInchStrategy_1INCH_renBTC.sol
+++ b/contracts/strategies/1inch/OneInchStrategy_1INCH_renBTC.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "@pancakeswap/pancake-swap-lib/contracts/token/BEP20/IBEP20.sol";
@@ -70,7 +72,7 @@ contract OneInchStrategy_1INCH_renBTC is StrategyBase {
     unsalvagableTokens[token1] = true;
   }
 
-  function depositArbCheck() public view returns(bool) {
+  function depositArbCheck() public pure returns(bool) {
     return true;
   }
 
@@ -164,7 +166,7 @@ contract OneInchStrategy_1INCH_renBTC is StrategyBase {
 
     uint256 bnbBalance = address(this).balance;
     WBNB wbnb = WBNB(payable(_wbnb));
-    wbnb.deposit.value(bnbBalance)();
+    wbnb.deposit{value: bnbBalance}();
 
     // share 30% of the 1INCH as a profit sharing reward
     notifyProfitInRewardToken(bnbBalance);
@@ -173,7 +175,7 @@ contract OneInchStrategy_1INCH_renBTC is StrategyBase {
     uint256 remainingBalance = IBEP20(_wbnb).balanceOf(address(this));
 
     wbnb.withdraw(remainingBalance);
-    IMooniswap(oneInchBNBLP).swap.value(remainingBalance)(
+    IMooniswap(oneInchBNBLP).swap{value: remainingBalance}(
       address(0),
       oneInch,
       remainingBalance,

--- a/contracts/strategies/1inch/interface/IFarmingRewards.sol
+++ b/contracts/strategies/1inch/interface/IFarmingRewards.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 interface IFarmingRewards {

--- a/contracts/strategies/1inch/interface/IFarmingRewardsV2.sol
+++ b/contracts/strategies/1inch/interface/IFarmingRewardsV2.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 interface IFarmingRewardsV2 {

--- a/contracts/strategies/1inch/interface/IMooniswap.sol
+++ b/contracts/strategies/1inch/interface/IMooniswap.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 interface IMooniswap {

--- a/contracts/strategies/bdo/bDollarStrategyMainnet_BDO_BNB.sol
+++ b/contracts/strategies/bdo/bDollarStrategyMainnet_BDO_BNB.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "../../base/masterchef/GeneralMasterChefStrategy.sol";

--- a/contracts/strategies/bdo/bDollarStrategyMainnet_BDO_BUSD.sol
+++ b/contracts/strategies/bdo/bDollarStrategyMainnet_BDO_BUSD.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "../../base/masterchef/GeneralMasterChefStrategy.sol";

--- a/contracts/strategies/bdo/bDollarStrategyMainnet_SBDO_BUSD.sol
+++ b/contracts/strategies/bdo/bDollarStrategyMainnet_SBDO_BUSD.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "../../base/masterchef/GeneralMasterChefStrategy.sol";

--- a/contracts/strategies/goose/GooseStrategyMainnet_EGG.sol
+++ b/contracts/strategies/goose/GooseStrategyMainnet_EGG.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "../../base/masterchef/GeneralMasterChefStrategy.sol";

--- a/contracts/strategies/goose/GooseStrategyMainnet_EGG_BNB.sol
+++ b/contracts/strategies/goose/GooseStrategyMainnet_EGG_BNB.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "../../base/masterchef/GeneralMasterChefStrategy.sol";

--- a/contracts/strategies/goose/GooseStrategyMainnet_EGG_BUSD.sol
+++ b/contracts/strategies/goose/GooseStrategyMainnet_EGG_BUSD.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "../../base/masterchef/GeneralMasterChefStrategy.sol";

--- a/contracts/strategies/pancakeswap/PancakeStrategyMainnet_BDO_BNB.sol
+++ b/contracts/strategies/pancakeswap/PancakeStrategyMainnet_BDO_BNB.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "../../base/pancake-base/PancakeMasterChefStrategy.sol";

--- a/contracts/strategies/pancakeswap/PancakeStrategyMainnet_BTCB_BNB.sol
+++ b/contracts/strategies/pancakeswap/PancakeStrategyMainnet_BTCB_BNB.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "../../base/pancake-base/PancakeMasterChefStrategy.sol";

--- a/contracts/strategies/pancakeswap/PancakeStrategyMainnet_BUSD_BNB.sol
+++ b/contracts/strategies/pancakeswap/PancakeStrategyMainnet_BUSD_BNB.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "../../base/pancake-base/PancakeMasterChefStrategy.sol";

--- a/contracts/strategies/pancakeswap/PancakeStrategyMainnet_CAKE.sol
+++ b/contracts/strategies/pancakeswap/PancakeStrategyMainnet_CAKE.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "../../base/pancake-base/PancakeMasterChefStrategy.sol";

--- a/contracts/strategies/pancakeswap/PancakeStrategyMainnet_CAKE_BNB.sol
+++ b/contracts/strategies/pancakeswap/PancakeStrategyMainnet_CAKE_BNB.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "../../base/pancake-base/PancakeMasterChefStrategy.sol";

--- a/contracts/strategies/pancakeswap/PancakeStrategyMainnet_ETH_BNB.sol
+++ b/contracts/strategies/pancakeswap/PancakeStrategyMainnet_ETH_BNB.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "../../base/pancake-base/PancakeMasterChefStrategy.sol";

--- a/contracts/strategies/pancakeswap/PancakeStrategyMainnet_LINK_BNB.sol
+++ b/contracts/strategies/pancakeswap/PancakeStrategyMainnet_LINK_BNB.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "../../base/pancake-base/PancakeMasterChefStrategy.sol";

--- a/contracts/strategies/pancakeswap/PancakeStrategyMainnet_UNI_BNB.sol
+++ b/contracts/strategies/pancakeswap/PancakeStrategyMainnet_UNI_BNB.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "../../base/pancake-base/PancakeMasterChefStrategy.sol";

--- a/contracts/strategies/pancakeswap/PancakeStrategyMainnet_USDT_BNB.sol
+++ b/contracts/strategies/pancakeswap/PancakeStrategyMainnet_USDT_BNB.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "../../base/pancake-base/PancakeMasterChefStrategy.sol";

--- a/contracts/strategies/pancakeswap/PancakeStrategyMainnet_XVS_BNB.sol
+++ b/contracts/strategies/pancakeswap/PancakeStrategyMainnet_XVS_BNB.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "../../base/pancake-base/PancakeMasterChefStrategy.sol";

--- a/contracts/strategies/venus/VenusFoldStrategyMainnet_BETH.sol
+++ b/contracts/strategies/venus/VenusFoldStrategyMainnet_BETH.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "../../base/venus-base/VenusFoldStrategy.sol";

--- a/contracts/strategies/venus/VenusFoldStrategyMainnet_BTCB.sol
+++ b/contracts/strategies/venus/VenusFoldStrategyMainnet_BTCB.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "../../base/venus-base/VenusFoldStrategy.sol";

--- a/contracts/strategies/venus/VenusFoldStrategyMainnet_BUSD.sol
+++ b/contracts/strategies/venus/VenusFoldStrategyMainnet_BUSD.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "../../base/venus-base/VenusFoldStrategy.sol";

--- a/contracts/strategies/venus/VenusFoldStrategyMainnet_DAI.sol
+++ b/contracts/strategies/venus/VenusFoldStrategyMainnet_DAI.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "../../base/venus-base/VenusFoldStrategy.sol";

--- a/contracts/strategies/venus/VenusFoldStrategyMainnet_ETH.sol
+++ b/contracts/strategies/venus/VenusFoldStrategyMainnet_ETH.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "../../base/venus-base/VenusFoldStrategy.sol";

--- a/contracts/strategies/venus/VenusFoldStrategyMainnet_USDC.sol
+++ b/contracts/strategies/venus/VenusFoldStrategyMainnet_USDC.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "../../base/venus-base/VenusFoldStrategy.sol";

--- a/contracts/strategies/venus/VenusFoldStrategyMainnet_USDT.sol
+++ b/contracts/strategies/venus/VenusFoldStrategyMainnet_USDT.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "../../base/venus-base/VenusFoldStrategy.sol";

--- a/contracts/strategies/venus/VenusFoldStrategyMainnet_WBNB.sol
+++ b/contracts/strategies/venus/VenusFoldStrategyMainnet_WBNB.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "../../base/venus-base/VenusWBNBFoldStrategy.sol";

--- a/contracts/strategies/venus/VenusFoldStrategyMainnet_XVS.sol
+++ b/contracts/strategies/venus/VenusFoldStrategyMainnet_XVS.sol
@@ -1,3 +1,5 @@
+//SPDX-License-Identifier: Unlicense
+
 pragma solidity 0.6.12;
 
 import "../../base/venus-base/VenusFoldStrategy.sol";

--- a/contracts/strategies/venus/VenusVAIStrategyMainnet.sol
+++ b/contracts/strategies/venus/VenusVAIStrategyMainnet.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+//SPDX-License-Identifier: Unlicense
 
 pragma solidity 0.6.12;
 
@@ -49,7 +49,7 @@ contract VenusVAIStrategyMainnet is BaseUpgradeableStrategy {
     liquidationPath = [venus, wbnb, busd, vai];
   }
 
-  function depositArbCheck() public view returns(bool) {
+  function depositArbCheck() public pure returns(bool) {
     return true;
   }
 


### PR DESCRIPTION
Fixed nearly all compile warnings, only ones left are because of missing license in 2 contracts from the @uniswap/v2-periphery package.